### PR TITLE
Fix location.sh and serverid.sh

### DIFF
--- a/location.sh
+++ b/location.sh
@@ -41,7 +41,7 @@ tee <<-EOF
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 EOF
 sleep 3
-bash /opt/plexguide/menu/serverid/serverid.sh
+bash /opt/plexguide/menu/interface/serverid.sh
 exit
 else
 

--- a/pgvault.func
+++ b/pgvault.func
@@ -412,7 +412,7 @@ tee <<-EOF
 🚀 PG Vault ~ Data Storage             📓 Reference: pgvault.pgblitz.com
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-📂 App Data to Backup
+📂 App Data available to Backup
 
 $notrun
 
@@ -453,7 +453,7 @@ tee <<-EOF
 🚀 PG Vault ~ Data Recall              📓 Reference: pgvault.pgblitz.com
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-📂 App Data to Restore
+📂 App Data available to Restore
 
 $notrun
 

--- a/pgvault.func
+++ b/pgvault.func
@@ -510,10 +510,10 @@ EOF
     primaryinterface
   elif [ "$typed" == "3" ]; then
     echo "0" > /var/plexguide/server.id.stored
-    bash /opt/plexguide/menu/serverid/serverid.sh
+    bash /opt/plexguide/menu/interface/serverid.sh
     primaryinterface
   elif [ "$typed" == "4" ]; then
-    bash /opt/plexguide/menu/data/location.sh
+    bash /opt/pgvault/location.sh
     primaryinterface
   elif [[ "$typed" == "Z" || "$typed" == "z" ]]; then
     exit

--- a/pgvault.func
+++ b/pgvault.func
@@ -412,7 +412,7 @@ tee <<-EOF
 🚀 PG Vault ~ Data Storage             📓 Reference: pgvault.pgblitz.com
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-📂 Potential Data to Backup
+📂 App Data to Backup
 
 $notrun
 
@@ -453,15 +453,15 @@ tee <<-EOF
 🚀 PG Vault ~ Data Recall              📓 Reference: pgvault.pgblitz.com
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-📂 Potential Data to Restore
+📂 App Data to Restore
 
 $notrun
 
-💾 Apps Queued for Backup
+💾 Apps Queued for Restore
 
 $buildup
 
-💬 Quitting? TYPE > exit | 💪 Ready to Backup? TYPE > deploy
+💬 Quitting? TYPE > exit | 💪 Ready to Restore? TYPE > deploy
 EOF
 read -p '🌍 Type APP for QUEUE | Press [ENTER]: ' typed < /dev/tty
 

--- a/restoreid.sh
+++ b/restoreid.sh
@@ -35,7 +35,7 @@ tee <<-EOF
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 EOF
 sleep 3
-bash /opt/plexguide/menu/serverid/serverid.sh
+bash /opt/plexguide/menu/interface/serverid.sh
 exit
 else
 


### PR DESCRIPTION
Some funtions in PGVault are broken due to missing paths.

/opt/plexguide/menu/serverid/serverid.sh was moved to /opt/plexguide/menu/interface/serverid.sh
/opt/plexguide/menu/data/location.sh was moved to /opt/pgvault/location.sh

This pull updates PGVault files to look at these new paths.