### PR TITLE
Backups were not running in custom processing path

### DIFF
--- a/pgvault.func
+++ b/pgvault.func
@@ -265,7 +265,7 @@ server_id=$(cat /var/plexguide/server.id)
 tar \
   --warning=no-file-changed --ignore-failed-read --absolute-names --warning=no-file-removed \
   --exclude-from=/opt/pgvault/exclude.list \
-  -C /opt/appdata/${program_var} -cvf /opt/appdata/plexguide/${program_var}.tar ./
+  -C /opt/appdata/${program_var} -cvf ${tarlocation}/${program_var}.tar ./
 
 #tar \
 #--warning=no-file-changed --ignore-failed-read --absolute-names --warning=no-file-removed \


### PR DESCRIPTION
When using custom processing paths, backup tars were saving to the default directory.